### PR TITLE
Fix datasource URL variable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     hostname: repl-orquestrator-app
     container_name: repl-orquestrator-app
     environment:
-      - PSTGRES_URL=jdbc:postgresql://repl-orquestrator-db:5432/postgres
+      - POSTGRES_URL=jdbc:postgresql://repl-orquestrator-db:5432/postgres
       - POSTGRES_USER=postgresql
       - POSTGRES_PASSWORD=123mudar
       - POSTGRES_INIT=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=${PSTGRES_URL}
+spring.datasource.url=${POSTGRES_URL}
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 spring.sql.init.mode=${POSTGRES_INIT}


### PR DESCRIPTION
## Summary
- correct typo in datasource URL property
- update docker-compose to use POSTGRES_URL

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684825fe412c83328f14a8d1b70d74b7