### PR TITLE
Fix request variable name in TopicService

### DIFF
--- a/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/services/TopicService.java
+++ b/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/services/TopicService.java
@@ -55,12 +55,12 @@ public class TopicService {
         topicRepository.saveAll(topics);
     }
 
-    public void insertTopics(Request resquest){
+    public void insertTopics(Request request){
         List<Topic> topicsEntities = new ArrayList<>();
-        String cluster = resquest.getCluster();
-        String action = resquest.getAction();
-        List<String> servers = resquest.getServers();
-        List<String> topics = resquest.getTopics();
+        String cluster = request.getCluster();
+        String action = request.getAction();
+        List<String> servers = request.getServers();
+        List<String> topics = request.getTopics();
         logger.info("Topics update. Action=" + action + ", cluster=" + cluster + ", servers=" + servers.toString() + ", topics_count=" + topics.size());
 
         if (Objects.equals(action, "redistribute")){


### PR DESCRIPTION
## Summary
- rename parameter `resquest` to `request` in `TopicService`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848299e22d08332af3c5769793e2ff0