### PR TITLE
Fix log typo

### DIFF
--- a/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/config/ProjectConfig.java
+++ b/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/config/ProjectConfig.java
@@ -37,7 +37,7 @@ public class ProjectConfig {
                             .roles(credential.getRole().toUpperCase())
                             .build();
                     users.createUser(user);
-                    logger.info("Loadded user \"" + credential.getUsername() + "\" to UserDetailsService.");
+                    logger.info("Loaded user \"" + credential.getUsername() + "\" to UserDetailsService.");
                 }
 
             } catch (JsonProcessingException e) {


### PR DESCRIPTION
## Summary
- correct a spelling mistake in ProjectConfig
- inspect other log messages for typos

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483c2b931c83328c4403a9d7fc6424