### PR TITLE
Add Credentials decoding unit test

### DIFF
--- a/src/test/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/CredentialsTest.java
+++ b/src/test/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/CredentialsTest.java
@@ -1,0 +1,34 @@
+package br.com.clusterlab.kafkaconfluentreplicatororchestrator;
+
+import br.com.clusterlab.kafkaconfluentreplicatororchestrator.config.Credentials;
+import br.com.clusterlab.kafkaconfluentreplicatororchestrator.dto.Credential;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CredentialsTest {
+
+    @Test
+    void decodeCredentialsFromBase64() throws Exception {
+        String json = "[{" +
+                "\"username\":\"user\"," +
+                "\"password\":\"pass\"," +
+                "\"encoder\":\"none\"," +
+                "\"role\":\"ADMIN\"," +
+                "\"sourceIp\":\"1.1.1.1\"}]";
+        String encoded = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+
+        Credential[] result = Credentials.getCredentials(encoded);
+
+        assertEquals(1, result.length);
+        Credential cred = result[0];
+        assertEquals("user", cred.getUsername());
+        assertEquals("pass", cred.getPassword());
+        assertEquals("none", cred.getEncoder());
+        assertEquals("ADMIN", cred.getRole());
+        assertEquals("1.1.1.1", cred.getSourceIp());
+    }
+}


### PR DESCRIPTION
## Summary
- add a new unit test `CredentialsTest` that verifies `Credentials.getCredentials` decodes a Base64 encoded JSON array into `Credential` objects

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c19d7e3348332b2ac0a9a7f93d76f