### PR TITLE
Fix log typo with parameters

### DIFF
--- a/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/config/ProjectConfig.java
+++ b/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/config/ProjectConfig.java
@@ -37,7 +37,7 @@ public class ProjectConfig {
                             .roles(credential.getRole().toUpperCase())
                             .build();
                     users.createUser(user);
-                    logger.info("Loaded user \"" + credential.getUsername() + "\" to UserDetailsService.");
+                    logger.info("Loaded user \"{}\" to UserDetailsService.", credential.getUsername());
                 }
 
             } catch (JsonProcessingException e) {


### PR DESCRIPTION
## Summary
- update the log statement in `ProjectConfig` to use placeholder syntax
- ensure file ends with newline

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c19d727908332a6c65ca89a8e06dc