### PR TITLE
Fix action regex validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ The compose file will start both the application and a Postgres instance require
 
 ## Example API usage
 A sample request payload is available in [template/request.json](template/request.json). Use it as a reference when sending POST requests to `/api/topic`.
+The `action` field only accepts the values `increment` or `redistribute`.

--- a/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/dto/Request.java
+++ b/src/main/java/br/com/clusterlab/kafkaconfluentreplicatororchestrator/dto/Request.java
@@ -22,7 +22,7 @@ import jakarta.validation.constraints.Pattern;
 @Generated("jsonschema2pojo")
 public class Request {
 
-    @Pattern(regexp = "^increment|redistribute",
+    @Pattern(regexp = "^(increment|redistribute)$",
             message="Action must be one of increment|redistribute")
     @NotNull
     @JsonProperty("action")


### PR DESCRIPTION
## Summary
- limit DTO action validation to only `increment` or `redistribute`
- document the allowed values in the README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c19d5ce388332a60b6391dc021372